### PR TITLE
Feature/rich-pir-struct

### DIFF
--- a/c/pir-code/example.c
+++ b/c/pir-code/example.c
@@ -5,13 +5,20 @@
 
 int main(int argc, char* argv[]) {
 	pir_t out;
+	wchar_t comp[255];
 
 	setlocale(LC_ALL, "");
 
-	pir_code_init(&out);
-	pir_code_write(L"Lyssavirus", &out);
+	if(argc != 2) {
+		return -1;
+	}
 
-	wprintf(L"%.*s\n", PIR_CODE_LENGTH, &out);
+	swprintf(comp, 255, L"%s", argv[1]);
+
+	pir_code_init(&out);
+	pir_code_write(comp, &out);
+
+	wprintf(L"%.*s\n", PIR_CODE_LENGTH, out.pir);
 	
 	return 0;
 }

--- a/c/pir-code/example.c
+++ b/c/pir-code/example.c
@@ -4,12 +4,14 @@
 #include <locale.h>
 
 int main(int argc, char* argv[]) {
-	char out[PIR_CODE_LENGTH];
+	pir_t out;
 
 	setlocale(LC_ALL, "");
 
-	write_pir_code(L"lyssavirus", out);
-	wprintf(L"%.*s\n", PIR_CODE_LENGTH, out);
+	pir_code_init(&out);
+	pir_code_write(L"Lyssavirus", &out);
+
+	wprintf(L"%.*s\n", PIR_CODE_LENGTH, &out);
 	
 	return 0;
 }

--- a/c/pir-code/pir.c
+++ b/c/pir-code/pir.c
@@ -43,18 +43,27 @@ const char * code[] = {
 		"966", "967"
 	};
 
-void write_pir_code(const wchar_t * s, char c[PIR_CODE_LENGTH]) {
+void pir_code_init(pir_t * pir) {
+	for(register size_t i = 0; i < PIR_CODE_LENGTH; i++) {
+		pir->pir[i] = '0';
+	}
+
+	pir->pos = 0;
+
+	return;
+}
+
+void pir_code_write(const wchar_t * ws, pir_t * pir) {
 	unsigned short digits[PIR_CODE_LENGTH] = {0};
-	size_t digits_pos = 0;
 
 	register unsigned int i, j;
 	register unsigned int offset = 0;
 
 	wchar_t cp[256];
 
-	if(wcslen(s) > 255) { return; }
+	if(wcslen(ws) > 255) { return; }
 
-	wcscpy(cp, s);
+	wcscpy(cp, ws);
 
 	for(i = 0; i < wcslen(cp); i++) {
 		cp[i] = latinize_lowercase(cp[i]);
@@ -65,8 +74,8 @@ void write_pir_code(const wchar_t * s, char c[PIR_CODE_LENGTH]) {
 		for(i = 0; i < sizeof(code)/sizeof(char*); i++) {
 			if(wcspfx(cp + offset, verb[i])) {
 				for(j = 0; j < strlen(code[i]); j++) {
-					digits[digits_pos % PIR_CODE_LENGTH] = (digits[digits_pos % PIR_CODE_LENGTH] + (code[i][j] - '0')) % 10;
-					digits_pos++;
+					digits[pir->pos % PIR_CODE_LENGTH] = (digits[pir->pos % PIR_CODE_LENGTH] + (code[i][j] - '0')) % 10;
+					pir->pos++;
 				}
 				offset += wcslen(verb[i]);
 				break;
@@ -78,6 +87,6 @@ void write_pir_code(const wchar_t * s, char c[PIR_CODE_LENGTH]) {
 	}
 
 	for(i = 0; i < PIR_CODE_LENGTH; i++) {
-		c[i] = '0' + digits[i];
+		pir->pir[i] = '0' + (digits[i] + (pir->pir[i] - '0')) % 10;
 	}
 }

--- a/c/pir-code/pir.h
+++ b/c/pir-code/pir.h
@@ -10,11 +10,23 @@
 
 #define PIR_CODE_LENGTH 5
 
+typedef struct {
+    char pir[PIR_CODE_LENGTH];
+    size_t pos;
+} pir_t;
+
+/**
+ * @brief Initializes a pir_t object so that the position is set to zero and every digit is '0'
+ * 
+ * @param pir The pir_t object to be initialized
+ */
+void pir_code_init(pir_t * pir);
+
 /**
  * @brief Writes a PIR code to the character array from a wide character string
  * 
- * @param s The (wide) string where the PIR code is to be calculated from
- * @param c The character array (not wide) of the max. PIR_CODE_LENGTH digits of the PIR code
+ * @param ws The (wide) string where the PIR code is to be calculated from
+ * @param pir The pir_t object where the resulting PIR code is written to
  */
-void write_pir_code(const wchar_t * s, char c[PIR_CODE_LENGTH]);
+void pir_code_write(const wchar_t * ws, pir_t * pir);
 #endif

--- a/c/pir-code/pir.h
+++ b/c/pir-code/pir.h
@@ -8,7 +8,7 @@
 
 #include "../string-util/string-util.h"
 
-#define PIR_CODE_LENGTH 5
+#define PIR_CODE_LENGTH 3
 
 typedef struct {
     char pir[PIR_CODE_LENGTH];


### PR DESCRIPTION
PIR code generation is now based on a custom type pir_t that stores the position of the "cursor", making it possible to write to the struct multiple times to append further text as long as the string is not broken between a code point (like "ck"). This was done for the span feature in eval that required generating the code for multiple, consecutive tokens.